### PR TITLE
Добавь обявление в dwgproc.pp взаимодействие с функцией dwg_get_entity_layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/zamtmn/fpdwg/issues/8
-Your prepared branch: issue-8-eb067c47
-Your prepared working directory: /tmp/gh-issue-solver-1759323220914
-Your forked repository: konard/fpdwg
-Original repository (upstream): zamtmn/fpdwg
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/zamtmn/fpdwg/issues/8
+Your prepared branch: issue-8-eb067c47
+Your prepared working directory: /tmp/gh-issue-solver-1759323220914
+Your forked repository: konard/fpdwg
+Original repository (upstream): zamtmn/fpdwg
+
+Proceed.

--- a/dwgproc.pp
+++ b/dwgproc.pp
@@ -92,6 +92,7 @@ interface
     dxf_read_file : function(const filename:pchar;
                              dwg:PDwg_Data):integer;extdecl;
     dwg_free : procedure(dwg:PDwg_Data);extdecl;
+    dwg_get_entity_layer : function(entity:PDwg_Object_Entity):PDwg_Object_LAYER;extdecl;
 
   procedure FreeLibreDWG;
   procedure LoadLibreDWG(lib : pchar = LibreDWG_Lib; reloadlib : Boolean = False);
@@ -260,6 +261,7 @@ implementation
     dwg_read_file:=nil;
     dxf_read_file:=nil;
     dwg_free:=nil;
+    dwg_get_entity_layer:=nil;
   end;
 
   procedure LoadLibreDWG(lib : pchar = LibreDWG_Lib; reloadlib : Boolean = False);
@@ -271,6 +273,7 @@ implementation
       pointer(dwg_read_file):=GetProcAddress(hlib,'dwg_read_file');
       pointer(dxf_read_file):=GetProcAddress(hlib,'dxf_read_file');
       pointer(dwg_free):=GetProcAddress(hlib,'dwg_free');
+      pointer(dwg_get_entity_layer):=GetProcAddress(hlib,'dwg_get_entity_layer');
     end;
     if hlib=0 then
       raise Exception.Create(format(rsCouldNotLoadLib,[lib]));


### PR DESCRIPTION
## 🎯 Описание / Description

Добавлена функция `dwg_get_entity_layer` из библиотеки LibreDWG в Pascal интерфейс, следуя существующему паттерну динамически загружаемых функций.

Added the `dwg_get_entity_layer` function from the LibreDWG library to the Pascal interface, following the existing pattern of dynamically loaded functions.

### 📋 Ссылка на задачу / Issue Reference
Fixes #8

## 🔧 Что изменено / Changes Made

### dwgproc.pp
1. **Объявление указателя на функцию** / **Function pointer declaration** (line 95):
   ```pascal
   dwg_get_entity_layer : function(entity:PDwg_Object_Entity):PDwg_Object_LAYER;extdecl;
   ```

2. **Инициализация в nil** / **Initialization to nil** in `FreeLibreDWG` (line 264)

3. **Динамическая загрузка** / **Dynamic loading** in `LoadLibreDWG` (line 276):
   ```pascal
   pointer(dwg_get_entity_layer):=GetProcAddress(hlib,'dwg_get_entity_layer');
   ```

## ✅ Паттерн / Pattern Followed

Реализация следует точно такому же паттерну, как и другие функции LibreDWG:
- `dwg_read_file`
- `dxf_read_file`
- `dwg_free`

The implementation follows exactly the same pattern as other LibreDWG functions.

## 📝 Сигнатура функции в C / C Function Signature

```c
EXPORT Dwg_Object_LAYER *
dwg_get_entity_layer (const Dwg_Object_Entity *restrict);
```

## 🧪 Проверка / Verification

- ✅ Типы `PDwg_Object_Entity` и `PDwg_Object_LAYER` определены в `dwg.pp` (lines 885, 901)
- ✅ Функция добавлена в три места согласно паттерну
- ✅ Синтаксис соответствует другим функциям

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)