### PR TITLE
Fix access violation error after libredwg update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/zamtmn/fpdwg/issues/13
+Your prepared branch: issue-13-c1d1ee2f
+Your prepared working directory: /tmp/gh-issue-solver-1759436617665
+Your forked repository: konard/fpdwg
+Original repository (upstream): zamtmn/fpdwg
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/zamtmn/fpdwg/issues/13
-Your prepared branch: issue-13-c1d1ee2f
-Your prepared working directory: /tmp/gh-issue-solver-1759436617665
-Your forked repository: konard/fpdwg
-Original repository (upstream): zamtmn/fpdwg
-
-Proceed.

--- a/dwg.pp
+++ b/dwg.pp
@@ -2207,6 +2207,7 @@ __attribute__((visibility("default"))) const char* dwg_color_method_name (unsign
           &end : BITCODE_3BD;
           thickness : BITCODE_BT;
           extrusion : BITCODE_BE;
+          unknown_r11 : BITCODE_2RD;
         end;
       Dwg_Entity_LINE = _dwg_entity_LINE;
       //PDwg_Entity_LINE = ^Dwg_Entity_LINE;
@@ -9843,8 +9844,8 @@ in declaration at line 7399 *)
       //P_dwg_object = ^_dwg_object;
       _dwg_object = record
           size : BITCODE_RL;
-          address : dword;
-          _type : dword;
+          address : PtrUInt;
+          _type : BITCODE_BS;
           index : BITCODE_RL;
           fixedtype : DWG_OBJECT_TYPE;
           name : Pchar;
@@ -9859,15 +9860,17 @@ in declaration at line 7399 *)
           parent : P_dwg_struct;
           klass : PDwg_Class;
           bitsize : BITCODE_RL;
-          bitsize_pos : dword;
-          hdlpos : dword;
+          bitsize_pos : PtrUInt;
+          hdlpos : PtrUInt;
           was_bitsize_set : BITCODE_B;
           has_strings : BITCODE_B;
           stringstream_size : BITCODE_RL;
           handlestream_size : BITCODE_UMC;
-          common_size : dword;
+          common_size : PtrUInt;
           num_unknown_bits : BITCODE_RL;
           unknown_bits : BITCODE_TF;
+          num_unknown_rest : BITCODE_RL;
+          unknown_rest : BITCODE_TF;
         end;
       Dwg_Object = _dwg_object;
       //PDwg_Object = ^Dwg_Object;

--- a/dwgproc.pp
+++ b/dwgproc.pp
@@ -199,9 +199,9 @@ implementation
       while (i<dwg.num_objects) do begin
         if DWGObj2LPDict.GetValue(dwg.&object[i].fixedtype,dod) then begin
           if (dod.LoadEntityProc<>nil) and (dwg.&object[i].tio.entity<>nil) then
-            dod.LoadEntityProc(ZContext,DWGContext,dwg.&object[i],@dwg.&object[i].tio.entity^.tio)
+            dod.LoadEntityProc(ZContext,DWGContext,dwg.&object[i],dwg.&object[i].tio.entity^.tio.UNUSED)
           else if (dod.LoadObjectProc<>nil) and (dwg.&object[i].tio.&object<>nil) then
-            dod.LoadObjectProc(ZContext,DWGContext,dwg.&object[i],@dwg.&object[i].tio.&object^.tio);
+            dod.LoadObjectProc(ZContext,DWGContext,dwg.&object[i],dwg.&object[i].tio.&object^.tio.DUMMY);
         end;
         if @lpp<>nil then
           lpp(data,i);


### PR DESCRIPTION
## Summary

Fixes #13 - Access violation error in dwgproc.pp:202 after libredwg library update.

## Root Cause

The access violation at address `$00000000000000065` was caused by structure layout mismatches between the C library (libredwg) and Pascal bindings. The mismatches caused fields to be read from incorrect memory offsets, resulting in the `entity` pointer containing garbage values that passed the nil check but failed on dereference.

## Changes Made

### 1. Fixed `_dwg_object` structure type mismatches (dwg.pp)

The following fields were using incorrect types that caused structure misalignment on 64-bit systems:

- `address`: Changed from `dword` (32-bit) to `PtrUInt` (64-bit on 64-bit systems) to match C's `size_t`
- `_type`: Changed from `dword` to `BITCODE_BS` (uint16_t) to match the correct C type
- `bitsize_pos`: Changed from `dword` to `PtrUInt` to match C's `size_t`
- `hdlpos`: Changed from `dword` to `PtrUInt` to match C's `size_t`  
- `common_size`: Changed from `dword` to `PtrUInt` to match C's `size_t`
- Added missing fields: `num_unknown_rest` and `unknown_rest`

### 2. Updated `_dwg_entity_LINE` structure (dwg.pp)

Added the missing `unknown_r11 : BITCODE_2RD` field to match the updated dwg.h from libredwg.

### 3. Reverted incorrect pointer access (dwgproc.pp)

A previous commit incorrectly changed the pointer access from accessing the union member value to taking the address of the union:

**Incorrect (was causing the error):**
```pascal
@dwg.&object[i].tio.entity^.tio
```

**Correct (restored):**
```pascal
dwg.&object[i].tio.entity^.tio.UNUSED
```

The `@` operator takes the address of the union itself, but `LoadEntityProc` expects a pointer to the actual entity data (the pointer VALUE stored in the union), not the address of the union container.

## Testing

Attempted compilation with Free Pascal compiler. The structural changes are correct, though full testing requires the `ghashmap` dependency.

## Impact

These changes ensure that:
- Structure layouts match between C and Pascal on 64-bit systems
- Entity pointers are read from the correct memory offsets
- Pointer values (not addresses) are correctly passed to load procedures

🤖 Generated with [Claude Code](https://claude.ai/code)